### PR TITLE
Upgrade from Pico CSS to its newer successor, Blades CSS, and make the project grid responsive

### DIFF
--- a/src/pallets/templates/index.html
+++ b/src/pallets/templates/index.html
@@ -4,7 +4,7 @@
   <section>
     {{ page.content_html | safe }}
   </section>
-  <section style="display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--pico-spacing);">
+  <section style="display: grid; grid-template-columns: repeat(auto-fill, minmax(clamp(16ch, 21%, 100%), 1fr)); gap: var(--pico-spacing);">
     {% for title in ("Flask", "Quart", "Jinja", "Click", "Werkzeug", "ItsDangerous", "MarkupSafe") %}
       {% set name = title.lower() %}
       <p>

--- a/src/pallets/templates/layout.html
+++ b/src/pallets/templates/layout.html
@@ -6,7 +6,7 @@
   <title>Pallets</title>
   <link rel=icon href="/static/pallets-logo.svg">
   <link rel="alternate" type="application/atom+xml" title="Blog" href="{{ url_for(".blog_feed") }}">
-  <link rel=stylesheet href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  <link rel=stylesheet href="https://cdn.jsdelivr.net/npm/@anyblades/blades@2.3.1/css/blades.min.css">
   <link rel=stylesheet href="/static/style.css">
   {% block extra_head %}{% endblock %}
 </head>


### PR DESCRIPTION
Hi Pallets Team! 👋
really like how your site looks with Pico CSS!

---

as you might know — Pico CSS is not actively maintained (last update was >1 year ago)

thus we took over the maintenance of `pico.css` version [here](https://github.com/anyblades/pico), and now shipping it as *Bl*ades CSS, a fully compatible and actively maintained successor to Pico CSS:

### https://blades.ninja/ <sup>= https://github.com/anyblades/blades</sup>

---

so, here is our micro-PR to:

1. upgrade Pico CSS => Blades CSS (drop-in replacement)
2. make the project grid responsive on mobile (using modern CSS' `minmax` and `clamp`)

| before (Pico CSS) | after (Blades CSS) |
| -- | -- |
| <img width="529" height="1006" alt="image" src="https://github.com/user-attachments/assets/2c4ad4ca-2b62-4f0e-b45c-b83cc9178e9b" /> | <img width="529" height="1006" alt="image" src="https://github.com/user-attachments/assets/61c56967-cfc4-46ea-8c5d-43532c3f40b5" /> |

🥷